### PR TITLE
Paclet info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cp -r src WallGoMatrix
-          cp WallgoMatrix.m WallgoMatrix
+          cp WallGoMatrix.m WallGoMatrix
           zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
           rm -r WallGoMatrix
           ls -a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          mkdir -p WallGoMatrix
           cp -r src WallGoMatrix/
           cp WallGoMatrix.m WallGoMatrix/
           zip -r WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           cp -r src WallGoMatrix/
           cp src/*.m WallGoMatrix/src/
           cp WallGoMatrix.m WallGoMatrix/
-          zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
+          zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix
           rm -r WallGoMatrix
           ls -a
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
 
       - name: Build Release Asset
         run: |
-          cp -r src WallGoMatrix
+          mkdir -p new_folder
+          cp -r src WallGoMatrix.m WallGoMatrix/
           zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
           tar -czf WallGoMatrix_${{ github.ref_name }}.tar.gz WallGoMatrix/*
           rm -r WallGoMatrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp -r src WallGoMatrix/
+          cp src/*.m WallGoMatrix/src/
           cp WallGoMatrix.m WallGoMatrix/
-          zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix
+          zip -r WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix
           rm -r WallGoMatrix
           ls -a
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,20 @@
-name: Release
+permissions:
+  contents: write
+  deployments: write
+
+name: Build and release
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
     
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Build Release Asset
-        run: |
-          mkdir -p WallGoMatrix
-          cp -r src WallGoMatrix.m WallGoMatrix/
-          zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
-          tar -czf WallGoMatrix_${{ github.ref_name }}.tar.gz WallGoMatrix/*
-          rm -r WallGoMatrix
-          ls -a
 
       - name: Create Release
         id: create_release
@@ -35,12 +27,22 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Build Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p WallGoMatrix
+          cp -r src WallGoMatrix.m WallGoMatrix/
+          zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
+          rm -r WallGoMatrix
+          ls -a
+
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./WallGoMatrix_${{ github.ref }}.zip
-          asset_name: WallGoMatrix_${{ github.ref }}.zip
+          asset_path: ./WallGoMatrix_${{ github.ref_name }}.zip
+          asset_name: WallGoMatrix_${{ github.ref_name }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           mkdir -p WallGoMatrix
           cp -r src WallGoMatrix/
+          cp src/*.m WallGoMatrix/src/
           cp WallGoMatrix.m WallGoMatrix/
           zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
           rm -r WallGoMatrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p WallGoMatrix
-          cp -r src WallGoMatrix.m WallGoMatrix/
+          cp -r src WallGoMatrix
+          cp WallgoMatrix.m WallgoMatrix
           zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
           rm -r WallGoMatrix
           ls -a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Build Release Asset
         run: |
-          mkdir -p new_folder
+          mkdir -p WallGoMatrix
           cp -r src WallGoMatrix.m WallGoMatrix/
           zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
           tar -czf WallGoMatrix_${{ github.ref_name }}.tar.gz WallGoMatrix/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp -r src WallGoMatrix
-          cp WallGoMatrix.m WallGoMatrix
+          cp -r src WallGoMatrix/
+          cp WallGoMatrix.m WallGoMatrix/
           zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
           rm -r WallGoMatrix
           ls -a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          mkdir -p WallGoMatrix
           cp -r src WallGoMatrix/
           cp WallGoMatrix.m WallGoMatrix/
           zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p WallGoMatrix
           cp -r src WallGoMatrix/
-          cp src/*.m WallGoMatrix/src/
           cp WallGoMatrix.m WallGoMatrix/
           zip WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix
           rm -r WallGoMatrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           cp -r src WallGoMatrix/
           cp WallGoMatrix.m WallGoMatrix/
-          zip -r WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix
+          zip -r WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix/*
           rm -r WallGoMatrix
           ls -a
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp src/*.m WallGoMatrix/src/
+          cp -r src WallGoMatrix/
           cp WallGoMatrix.m WallGoMatrix/
           zip -r WallGoMatrix_${{ github.ref_name }}.zip WallGoMatrix
           rm -r WallGoMatrix

--- a/Kernel/init.m
+++ b/Kernel/init.m
@@ -1,0 +1,5 @@
+(* ::Package:: *)
+
+(* Wolfram Language Init File *)
+
+Get[ "WallGoMatrix`WallGoMatrix`"]

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,0 +1,12 @@
+(* ::Package:: *)
+
+(* Paclet Info File *)
+
+(* created 2024/10/09*)
+
+Paclet[
+    Name -> "WallGoMatrix",
+    Version -> "0.1.0",
+    MathematicaVersion -> "13+",
+    Creator -> "Andreas Ekstedt, Oliver Gould, Joonas Hirvonen, Benoit Laurent, Lauri Niemi, Philipp Schicho, Jorinde van de Vis"
+]

--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -6,7 +6,7 @@
 
 Paclet[
     Name -> "WallGoMatrix",
-    Version -> "0.1.0",
+    Version -> "0.1.1",
     MathematicaVersion -> "13+",
     Creator -> "Andreas Ekstedt, Oliver Gould, Joonas Hirvonen, Benoit Laurent, Lauri Niemi, Philipp Schicho, Jorinde van de Vis"
 ]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ WallGoMatrix is written in Wolfram Mathematica, and depends on the Mathematica p
 
 WallGoMatrix builds on [DRalgo](https://github.com/DR-algo/DRalgo) version 1.2, but the required elements are included directly in the WallGoMatrix package, so separate installation of DRalgo is not necessary.
 
+For non-commercial use,
+**WallGoMatrix** can be run via
+the [Wolfram Engine](https://www.wolfram.com/engine/).
+The Wolfram Engine is essentially the core computational engine of Wolfram Mathematica, and it can be used to run scripts, including those written in the Wolfram Language, without requiring a full Mathematica installation.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ To run the example files, you can use the following command:
 
     $ wolframscript -file examples/qcd.m 
 
+One requirement for the above command is an active `WolframKernel`.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ For non-commercial use,
 **WallGoMatrix** can be run via
 the [Wolfram Engine](https://www.wolfram.com/engine/).
 The Wolfram Engine is essentially the core computational engine of Wolfram Mathematica, and it can be used to run scripts, including those written in the Wolfram Language, without requiring a full Mathematica installation.
+As an example one can run:
+
+    wolframscript -file examples/qcd.m 
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -41,10 +41,15 @@ zip file from the following link:
 
 ![GitHub Downloads (package, latest release)](https://img.shields.io/github/downloads/Wall-Go/WallGo/latest/total)
 
-Unpack the zip file and then put the WallGoMatrix directory inside either the base
-or the user Mathematica Applications directory. The locations of these directories
-can be found by inspecting **$BaseDirectory** or **$UserBaseDirectory** within
-Mathematica. For versions of Mathematica before 14.1, the paths are commonly the
+After unpacking the zip file, place the **WallGoMatrix** directory inside the **Applications** folder within either the base or user-specific **Mathematica Applications** directory. These directories store Mathematica packages and can be located by evaluating the variables **`$BaseDirectory`** and **`$UserBaseDirectory`** within a Mathematica session.
+To find these directories, you can run the following command in Mathematica:
+
+```mathematica
+Print["Base Directory: ", FileNameJoin[{$BaseDirectory, "Applications"}]]
+Print["User Base Directory: ", FileNameJoin[{$UserBaseDirectory, "Applications"}]]
+```
+
+For versions of Mathematica before 14.1, the paths are commonly the
 following ones
 
 **Linux**
@@ -52,19 +57,22 @@ following ones
 - ~/.Mathematica/Applications
 
 **macOS**
-- ~/Library/Mathematica/Applications/GroupMath
+- ~/Library/Mathematica/Applications
 
 **Windows**
 - C:\ProgramData\Mathematica\Applications 
 - C:\Users\(computer name)\AppData\Roaming\Mathematica\Applications
 
-Note that from Mathematica 14.1 onwards this directory contains *Wolfram* rather than
-*Mathematica*.
+Note that from Mathematica 14.1 onwards,
+these directories are renamed to contain Wolfram instead of Mathematica.
+For example, the path for macOS becomes `~/Library/Wolfram/Applications`.
 
 Once the WallGoMatrix directory has been put inside the Mathematica applications
 directory, the package can be loaded from within Mathematica using
 
-    <<WallGoMatrix`
+```mathematica
+<<WallGoMatrix`
+```
 
 To see how WallGoMatrix is used in practice, we recommend taking a look at the
 [examples](https://github.com/Wall-Go/WallGoMatrix/tree/main/examples).
@@ -78,13 +86,14 @@ WallGoMatrix is written in Wolfram Mathematica, and depends on the Mathematica p
 
 WallGoMatrix builds on [DRalgo](https://github.com/DR-algo/DRalgo) version 1.2, but the required elements are included directly in the WallGoMatrix package, so separate installation of DRalgo is not necessary.
 
-For non-commercial use,
-**WallGoMatrix** can be run via
-the [Wolfram Engine](https://www.wolfram.com/engine/).
-The Wolfram Engine is essentially the core computational engine of Wolfram Mathematica, and it can be used to run scripts, including those written in the Wolfram Language, without requiring a full Mathematica installation.
-As an example one can run:
+### Running the examples
 
-    wolframscript -file examples/qcd.m 
+Within **WallGo**, **WallGoMatrix** is executed using 
+[Wolframscript](https://www.wolfram.com/wolframscript/).
+Wolframscript provides the core computational capabilities of Wolfram Mathematica and allows Wolfram Language scripts to be run without needing a full Mathematica installation.
+To run the example files, you can use the following command:
+
+    $ wolframscript -file examples/qcd.m 
 
 
 ## License

--- a/WallGoMatrix.m
+++ b/WallGoMatrix.m
@@ -21,6 +21,17 @@
 (* ------------------------------------------------------------------------ *)
 
 
+$WallGoMatrixVersion::usage =
+"$WallGoMatrixVersion is a string that represents the version of WallGoMatrix.";
+$WallGoMatrixVersionDate::usage =
+"$WallGoMatrixVersionDate is a string that represents the version date of WallGoMatrix.";
+
+
+(* Set the version number *)
+WallGoMatrix`$WallGoMatrixVersion = "0.1.1";
+WallGoMatrix`$WallGoMatrixVersionDate = "(09-10-2024)";
+
+
 BeginPackage["WallGoMatrix`"]
 
 
@@ -41,7 +52,7 @@ AppendTo[result,Row[{
 	TexFor["GOGOGOGOGOGOGOGOGOGOGOGO "],
 	TexFor["WallGoMatrix"],
 	TexFor[" GOGOGOGOGOGOGOGOGOGOGGOGOGO"]}]];
-AppendTo[result,Row[{"Version: "//TexFor,"0.1.0 (09-10-2024)"//TexFor}]];
+AppendTo[result,Row[{"Version: "//TexFor,ToString[$WallGoMatrixVersion]<>" "<>ToString[$WallGoMatrixVersionDate]//TexFor}]];
 AppendTo[result,Row[{"Authors: "//TexFor,
     Hyperlink["Andreas Ekstedt","https://inspirehep.net/authors/1799400"],", "//TexFor,
     Hyperlink["Oliver Gould","https://inspirehep.net/authors/1606373"],", "//TexFor,
@@ -94,7 +105,13 @@ SymmetryBreaking::usage=
 "Classify different scalar, fermion, and vector representations into respective particles using VEV-induced masses.
 As an output particle i are given as {\!\(\*SubscriptBox[\(r\), \(i\)]\),\!\(\*SubscriptBox[\(m\), \(i\)]\)} where \!\(\*SubscriptBox[\(r\), \(i\)]\) is the label of the representation and \!\(\*SubscriptBox[\(m\), \(i\)]\) is the label of the particle mass in that representation"
 ExportMatrixElements::usage=
-"ExportMatrixElements[file,particleList,UserMasses,UserCouplings,ParticleName,ParticleMasses,OptionsPattern[]]\n"<>
+"ExportMatrixElements[\!\(\*
+StyleBox[\"fileName\",\nFontSlant->\"Italic\"]\),\!\(\*
+StyleBox[\"particleList\",\nFontSlant->\"Italic\"]\),\!\(\*
+StyleBox[\"UserMasses\",\nFontSlant->\"Italic\"]\),\!\(\*
+StyleBox[\"UserCouplings\",\nFontSlant->\"Italic\"]\),\!\(\*
+StyleBox[\"ParticleName\",\nFontSlant->\"Italic\"]\),\!\(\*
+StyleBox[\"ParticleMasses\",\nFontSlant->\"Italic\"]\),OptionsPattern[]]\n"<>
 "Generates all possible matrix elements with the external particles specified in particleList.\n"<>
 "The format can be specified by the option Format, with currently supported options: X=txt,json,hdf5,all,none, "<>
 "the last two options exports the result in all possible formats, and in none, respectively.\n"<>
@@ -498,7 +515,7 @@ ExportTo["txt"][MatrixElements_,OutOfEqParticles_,ParticleName_,UserCouplings_,f
 ]
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*MatrixElements: Exporting the results*)
 
 
@@ -520,8 +537,19 @@ Block[
 	ParticleMassesI=ParticleMasses,ExportTXT,ExportH5,
 	Cij,ParticleInfo,LightParticles,particleListFull,
 	CouplingInfo,MatrixElements,OutOfEqParticles,RepMasses,RepCouplings,
-	FormatOptions,userFormat,MatrixElementsList,userParameters
+	FormatOptions,userFormat,MatrixElementsList,userParameters,
+	privFile=file,commandLineArgs
 },
+	
+	commandLineArgs = $ScriptCommandLine;
+
+	(*Loop over command line input to overrule output file name for command line usage*)
+	Do[
+		If[
+			commandLineArgs[[i]] == "--outputFile",
+			privFile = commandLineArgs[[i + 1]]], (* Get the value after the flag *)
+		{i, 2, Length[commandLineArgs] - 1} (* Start from 2 and go up to the second-to-last element *)
+	];
 
 (*Specifies if the first particle should be normalized by the number of degrees of freedom*)
 	bNormalizeWithDOF = OptionValue[NormalizeWithDOF];
@@ -563,11 +591,11 @@ Block[
 	   (* Iterate over each format and perform the export *)
 	   Do[
 	     Switch[fmt,
-	       "txt", ExportTo["txt"][MatrixElementsList, OutOfEqParticles, ParticleName, UserCouplings, file],
-	       "hdf5", ExportTo["hdf5"][Cij, OutOfEqParticles, ParticleName, UserCouplings, file],
+	       "txt", ExportTo["txt"][MatrixElementsList, OutOfEqParticles, ParticleName, UserCouplings, privFile],
+	       "hdf5", ExportTo["hdf5"][Cij, OutOfEqParticles, ParticleName, UserCouplings, privFile],
 	       "json",
 	       userParameters = Flatten[Join[UserCouplings, ParticleMasses]] // DeleteDuplicates;
-	       ExportTo["json"][MatrixElementsList, ParticleName, userParameters, file]
+	       ExportTo["json"][MatrixElementsList, ParticleName, userParameters, privFile]
 	     ],
 	     {fmt, userFormatsList}
 	   ],

--- a/WallGoMatrix.m
+++ b/WallGoMatrix.m
@@ -191,7 +191,7 @@ Begin["`Private`"]
 (*Loads DRalgo model creation*)
 Get[FileNameJoin[{$WallGoMatrixDirectory,"src/modelCreation.m"}]];
 (*Loads matrix element creation*)
-Get[FileNameJoin[{$WallGoMatrixDirectory,"src/matrixelements.m"}]];
+Get[FileNameJoin[{$WallGoMatrixDirectory,"src/matrixElements.m"}]];
 
 
 (* ::Section::Closed:: *)

--- a/WallGoMatrix.m
+++ b/WallGoMatrix.m
@@ -172,9 +172,9 @@ Begin["`Private`"]
 	Loads all functions.
 *)
 (*Loads DRalgo model creation*)
-Get[FileNameJoin[{$WallGoMatrixDirectory,"modelCreation.m"}]];
+Get[FileNameJoin[{$WallGoMatrixDirectory,"src/modelCreation.m"}]];
 (*Loads matrix element creation*)
-Get[FileNameJoin[{$WallGoMatrixDirectory,"matrixelements.m"}]];
+Get[FileNameJoin[{$WallGoMatrixDirectory,"src/matrixelements.m"}]];
 
 
 (* ::Section::Closed:: *)

--- a/examples/2hdm.m
+++ b/examples/2hdm.m
@@ -193,7 +193,6 @@ ParticleName={
 (*
 	output of matrix elements
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElements.2hdm";
 
 MatrixElements=ExportMatrixElements[

--- a/examples/2hdm.m
+++ b/examples/2hdm.m
@@ -1,9 +1,12 @@
 (* ::Package:: *)
 
-Quit[];
+(*Quit[];*)
 
 
-SetDirectory[NotebookDirectory[]];
+If[$InputFileName=="",
+	SetDirectory[NotebookDirectory[]],
+	SetDirectory[DirectoryName[$InputFileName]]
+]
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;

--- a/examples/2hdm.m
+++ b/examples/2hdm.m
@@ -7,7 +7,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)
@@ -205,6 +205,4 @@ MatrixElements=ExportMatrixElements[
 		Replacements->{lam4H->0,lam5H->0},
 		Format->{"json","txt"},
 		NormalizeWithDOF->False}];
-
-
 

--- a/examples/2hdm.m
+++ b/examples/2hdm.m
@@ -10,7 +10,7 @@ If[$InputFileName=="",
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../WallGoMatrix.m
+<<WallGoMatrix`
 
 
 (* ::Chapter:: *)

--- a/examples/SMFull.m
+++ b/examples/SMFull.m
@@ -185,7 +185,6 @@ ParticleName={
 (*
 	output of matrix elements
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElementsFull";
 
 MatrixElements=ExportMatrixElements[
@@ -201,7 +200,6 @@ MatrixElements=ExportMatrixElements[
 (*
 	output of matrix elements 
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElementsFull.LL";
 
 MatrixElements=ExportMatrixElements[

--- a/examples/SMFull.m
+++ b/examples/SMFull.m
@@ -7,7 +7,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)

--- a/examples/SMFull.m
+++ b/examples/SMFull.m
@@ -1,9 +1,12 @@
 (* ::Package:: *)
 
-Quit[];
+(*Quit[];*)
 
 
-SetDirectory[NotebookDirectory[]];
+If[$InputFileName=="",
+	SetDirectory[NotebookDirectory[]],
+	SetDirectory[DirectoryName[$InputFileName]]
+]
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;

--- a/examples/SMFull.m
+++ b/examples/SMFull.m
@@ -10,7 +10,7 @@ If[$InputFileName=="",
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../WallGoMatrix.m
+<<WallGoMatrix`
 
 
 (* ::Chapter:: *)

--- a/examples/SMscalar.m
+++ b/examples/SMscalar.m
@@ -7,7 +7,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)

--- a/examples/SMscalar.m
+++ b/examples/SMscalar.m
@@ -1,9 +1,12 @@
 (* ::Package:: *)
 
-Quit[];
+(*Quit[];*)
 
 
-SetDirectory[NotebookDirectory[]];
+If[$InputFileName=="",
+	SetDirectory[NotebookDirectory[]],
+	SetDirectory[DirectoryName[$InputFileName]]
+]
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;

--- a/examples/SMscalar.m
+++ b/examples/SMscalar.m
@@ -134,7 +134,6 @@ ParticleName={"TopL","TopR","BotR","Gluon","W","Higgs"};
 (*
 	output of matrix elements
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElements.scalar";
 MatrixElements=ExportMatrixElements[
 	OutputFile,

--- a/examples/SMscalar.m
+++ b/examples/SMscalar.m
@@ -10,7 +10,7 @@ If[$InputFileName=="",
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../WallGoMatrix.m
+<<WallGoMatrix`
 
 
 (* ::Chapter:: *)

--- a/examples/electroWeak.m
+++ b/examples/electroWeak.m
@@ -7,7 +7,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)

--- a/examples/electroWeak.m
+++ b/examples/electroWeak.m
@@ -126,7 +126,6 @@ ParticleName={"TopL","TopR",(*"BotR",*)"Gluon","W","H"};
 (*
 	output of matrix elements
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElements.ew";
 MatrixElements=ExportMatrixElements[
 	OutputFile,

--- a/examples/electroWeak.m
+++ b/examples/electroWeak.m
@@ -1,9 +1,12 @@
 (* ::Package:: *)
 
-Quit[];
+(*Quit[];*)
 
 
-SetDirectory[NotebookDirectory[]];
+If[$InputFileName=="",
+	SetDirectory[NotebookDirectory[]],
+	SetDirectory[DirectoryName[$InputFileName]]
+]
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;

--- a/examples/electroWeak.m
+++ b/examples/electroWeak.m
@@ -10,7 +10,7 @@ If[$InputFileName=="",
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../WallGoMatrix.m
+<<WallGoMatrix`
 
 
 (* ::Chapter:: *)

--- a/examples/qcd.m
+++ b/examples/qcd.m
@@ -10,7 +10,7 @@ If[$InputFileName=="",
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../WallGoMatrix.m
+<<WallGoMatrix`
 
 
 (* ::Chapter:: *)
@@ -104,6 +104,4 @@ MatrixElements=ExportMatrixElements[
 	ParticleName,
 	ParticleMasses,
 	{TruncateAtLeadingLog->True,Format->{"json","txt"}}];
-
-
 

--- a/examples/qcd.m
+++ b/examples/qcd.m
@@ -94,7 +94,6 @@ ParticleName={"Top", "Gluon"};
 (*
 	output of matrix elements
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElements.qcd";
 MatrixElements=ExportMatrixElements[
 	OutputFile,

--- a/examples/qcd.m
+++ b/examples/qcd.m
@@ -7,14 +7,14 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)
 (*QCD*)
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Model*)
 
 
@@ -101,6 +101,7 @@ MatrixElements=ExportMatrixElements[
 	ParticleName,
 	ParticleMasses,
 	{TruncateAtLeadingLog->True,Format->{"json","txt"}}];
+
 
 
 

--- a/examples/qcd.m
+++ b/examples/qcd.m
@@ -1,9 +1,12 @@
 (* ::Package:: *)
 
-Quit[];
+(*Quit[];*)
 
 
-SetDirectory[NotebookDirectory[]];
+If[$InputFileName=="",
+	SetDirectory[NotebookDirectory[]],
+	SetDirectory[DirectoryName[$InputFileName]]
+]
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
@@ -101,8 +104,6 @@ MatrixElements=ExportMatrixElements[
 	ParticleName,
 	ParticleMasses,
 	{TruncateAtLeadingLog->True,Format->{"json","txt"}}];
-
-
 
 
 

--- a/examples/xsm.m
+++ b/examples/xsm.m
@@ -194,7 +194,6 @@ ParticleName={"TopL","TopR","Gluon","W","Z","H","S"};
 (*
 	output of matrix elements
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElements.xsm";
 MatrixElements=ExportMatrixElements[
 	OutputFile,
@@ -263,7 +262,6 @@ ParticleName={"Top","Gluon","W","Z","H","S"};
 (*
 	output of matrix elements
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElements.xsm.qcd";
 MatrixElements=ExportMatrixElements[
 	OutputFile,

--- a/examples/xsm.m
+++ b/examples/xsm.m
@@ -7,7 +7,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)

--- a/examples/xsm.m
+++ b/examples/xsm.m
@@ -1,9 +1,12 @@
 (* ::Package:: *)
 
-Quit[];
+(*Quit[];*)
 
 
-SetDirectory[NotebookDirectory[]];
+If[$InputFileName=="",
+	SetDirectory[NotebookDirectory[]],
+	SetDirectory[DirectoryName[$InputFileName]]
+]
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;

--- a/examples/xsm.m
+++ b/examples/xsm.m
@@ -10,7 +10,7 @@ If[$InputFileName=="",
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../WallGoMatrix.m
+<<WallGoMatrix`
 
 
 (* ::Chapter:: *)

--- a/examples/yukawa.m
+++ b/examples/yukawa.m
@@ -7,7 +7,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)

--- a/examples/yukawa.m
+++ b/examples/yukawa.m
@@ -3,7 +3,10 @@
 (*Quit[];*)
 
 
-SetDirectory[NotebookDirectory[]];
+If[$InputFileName=="",
+	SetDirectory[NotebookDirectory[]],
+	SetDirectory[DirectoryName[$InputFileName]]
+]
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;

--- a/examples/yukawa.m
+++ b/examples/yukawa.m
@@ -1,6 +1,6 @@
 (* ::Package:: *)
 
-Quit[];
+(*Quit[];*)
 
 
 SetDirectory[NotebookDirectory[]];
@@ -133,9 +133,6 @@ RepFermionR=CreateParticle[{2},"F"];
 
 (*Vector bosons*)
 RepZ=CreateParticle[{1},"V"];
-
-
-CreateParticle[{1,2},"F"]
 
 
 (*

--- a/examples/yukawa.m
+++ b/examples/yukawa.m
@@ -162,7 +162,6 @@ UserCouplings=Variables@Normal@{Ysff,gvss,gvff,gvvv,\[Lambda]4,\[Lambda]3}//Dele
 (*
 	output of matrix elements
 *)
-SetDirectory[NotebookDirectory[]];
 OutputFile="output/matrixElements.yukawa";
 ParticleName={"Phi","PsiL","PsiR"};
 MatrixElements=ExportMatrixElements[

--- a/examples/yukawa.m
+++ b/examples/yukawa.m
@@ -10,7 +10,7 @@ If[$InputFileName=="",
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../WallGoMatrix.m
+<<WallGoMatrix`
 
 
 (* ::Chapter:: *)

--- a/tests/qcd.test.m
+++ b/tests/qcd.test.m
@@ -13,7 +13,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallgoMatrix.m
+<<../WallgoMatrix.m
 
 
 (* ::Chapter:: *)
@@ -221,7 +221,5 @@ TestCreate[
 
 report=TestReport[testList]
 report["ResultsDataset"]
-
-
 
 

--- a/tests/u1higgs.test.m
+++ b/tests/u1higgs.test.m
@@ -13,7 +13,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)
@@ -207,7 +207,5 @@ TestCreate[
 
 report=TestReport[testList]
 report["ResultsDataset"]
-
-
 
 

--- a/tests/u1higgs_yukawa.test.m
+++ b/tests/u1higgs_yukawa.test.m
@@ -13,7 +13,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)

--- a/tests/xsm.test.m
+++ b/tests/xsm.test.m
@@ -7,7 +7,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)
@@ -511,6 +511,4 @@ TestCreate[
 
 report=TestReport[testList]
 report["ResultsDataset"]
-
-
 

--- a/tests/yukawa.test.m
+++ b/tests/yukawa.test.m
@@ -13,7 +13,7 @@ SetDirectory[NotebookDirectory[]];
 (*Put this if you want to create multiple model-files with the same kernel*)
 $GroupMathMultipleModels=True;
 $LoadGroupMath=True;
-<<../src/WallGoMatrix.m
+<<../WallGoMatrix.m
 
 
 (* ::Chapter:: *)
@@ -251,6 +251,4 @@ TestCreate[
 
 report=TestReport[testList]
 report["ResultsDataset"]
-
-
 


### PR DESCRIPTION
-add information in case paclet packaging is desired at some point.
-add command line parsing for --outputFile. This is useful for integrated use with wallgo python
-add version number (should be updated automatically in the future)