### PR TITLE
New version packaging

### DIFF
--- a/Kernel/WallGoMatrix.m
+++ b/Kernel/WallGoMatrix.m
@@ -443,11 +443,10 @@ DownloadPackage[url_, targetName_]:=Module[{zipPath, targetFolder, targetDir, ta
 	Functions from GroupMath are used to create the model.
 *)
 If[$LoadGroupMath,
-	Unprotect[BlockDiagonalMatrix];
 	If[$InstallGroupMath,
 		If[
 			Quiet[Check[Needs["GroupMath`"], True]],
-			DownloadPackage["https://renatofonseca.net/groupmath/ProgramVersions/GroupMath-1.1.2.zip","GroupMath"];
+			DownloadPackage["https://renatofonseca.net/groupmath/ProgramVersions/GroupMath-1.1.3.zip","GroupMath"];
 			Print[Style["GroupMath installed.","Text", Red, Bold]];
 		]
 	];

--- a/Kernel/modelCreation.m
+++ b/Kernel/modelCreation.m
@@ -6,9 +6,9 @@
 
 (*
       	This software is covered by the GNU General Public License 3.
-       	Copyright (C) 2021-2024 Andreas Ekstedt
-       	Copyright (C) 2021-2024 Philipp Schicho
-       	Copyright (C) 2021-2024 Tuomas V.I. Tenkanen
+       	Copyright (C) 2021-2025 Andreas Ekstedt
+       	Copyright (C) 2021-2025 Philipp Schicho
+       	Copyright (C) 2021-2025 Tuomas V.I. Tenkanen
 *)
 
 (* :Summary:	Creating models from model file.							*)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ WallGoMatrix is written in the Wolfram Mathematica language, and depends on the 
 It has been tested on the following versions.
 
 - [Mathematica](https://www.wolfram.com/mathematica/) versions 12.x, 13.x and 14.x
-    - [GroupMath](https://renatofonseca.net/groupmath) version 1.1.2
+    - [GroupMath](https://renatofonseca.net/groupmath) version 1.1.3
 
 GroupMath can be either manually obtained from the link above or by setting the following flag before loading WallGoMatrix in Mathematica
 ```mathematica

--- a/buildPaclet.m
+++ b/buildPaclet.m
@@ -4,7 +4,7 @@
 
 
 (* Define the temporary directory *)
-tempDir = CreateDirectory[FileNameJoin[{NotebookDirectory[], "TempPaclet"}]];
+tempDir = CreateDirectory[FileNameJoin[{NotebookDirectory[], "build", "TempPaclet"}]];
 
 (* Copy Kernel directory and PacletInfo.m to the temporary directory *)
 CopyDirectory[FileNameJoin[{NotebookDirectory[], "Kernel"}], FileNameJoin[{tempDir, "Kernel"}]];

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,18 +1,24 @@
 # Examples
-This folder contains examples of model implementations in WallGoMatrix.
+This folder contains examples of model implementations in `WallGoMatrix`.
 Instructions can be found in the [manual](https://arxiv.org/abs/2411.04970).
 
 # Loading WallGoMatrix
 The line 
-    Get["WallGo`WallGoMatrix`"]
+    ```Get["WallGo`WallGoMatrix`"]```
 in the first cell of each example loads the installed version of WallGoMatrix. See the [manual](https://arxiv.org/abs/2411.04970) or the [WallGoMatrix repo](https://github.com/Wall-Go/WallGoMatrix) for installation instructions.
 If you want to run with the version of WallGoMatrix in the local folder (e.g. to test changes in the source code), use instead:
-    Get["../Kernel/WallGoMatrix.m"]
+    ```Get["../Kernel/WallGoMatrix.m"]```
 
 # Models implemented in WallGo
 Some of the model files in this folder are related to models implemented in the [WallGo repository](https://github.com/Wall-Go/WallGo):
-- qcd.m gives the matrix elements for ManySinglets and SingletStandardModel_Z2
-- idm.m gives the matrix elements for InertDoubletModel
-- electroWeak.m gives the matrix elements for StandardModel
-- yukawa.m gives the matrix elements for Yukawa
+- `2hdm.m` gives the matrix elements for the Two Higgs Doublet Model
+- `2scalars.m` gives the matrix elements for the pure scalar sector of the Two Higgs Doublet Model
+- `SMFull.m` gives the matrix elements for the StandardModel
+- `SMSimplified.m` gives the matrix elements for the StandardModel (only quarks + gauge bosons)
+- `idm.m` gives the matrix elements for InertDoubletModel
+- `qcd.m` gives the matrix elements for ManySinglets and SingletStandardModel_Z2
+- `xsm.m` gives the matrix elements for SingletStandardModel_Z2 beyond the QCD sector
+- `weak.m` gives the matrix elements for QCD and W-bosons
+- `yukawa.m` gives the matrix elements for the Yukawa Model
+
 The WallGo repository contains copies of these example files.

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ the [WallGo repository](https://github.com/Wall-Go/WallGo):
 - `qcd.m` gives the matrix elements for ManySinglets and SingletStandardModel_Z2
 - `xsm.m` gives the matrix elements for SingletStandardModel_Z2 beyond the QCD sector
 - `yukawa.m` gives the matrix elements for the Yukawa Model
+The WallGo repository contains copies of these example files.
 
 On top of these, we provide several additional example model files that illustrate
 various features of WallGoMatrix:
@@ -24,5 +25,3 @@ various features of WallGoMatrix:
 - `SMFull.m` gives the matrix elements for the StandardModel
 - `SMSimplified.m` gives the matrix elements for the StandardModel (only quarks + gauge bosons)
 - `weak.m` gives the matrix elements for QCD and W-bosons
-
-The WallGo repository contains copies of these example files.i

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,15 +10,19 @@ If you want to run with the version of WallGoMatrix in the local folder (e.g. to
     ```Get["../Kernel/WallGoMatrix.m"]```
 
 # Models implemented in WallGo
-Some of the model files in this folder are related to models implemented in the [WallGo repository](https://github.com/Wall-Go/WallGo):
+Some of the model files in this folder are related to models implemented in
+the [WallGo repository](https://github.com/Wall-Go/WallGo):
+- `idm.m` gives the matrix elements for InertDoubletModel
+- `qcd.m` gives the matrix elements for ManySinglets and SingletStandardModel_Z2
+- `xsm.m` gives the matrix elements for SingletStandardModel_Z2 beyond the QCD sector
+- `yukawa.m` gives the matrix elements for the Yukawa Model
+
+On top of these, we provide several additional example model files that illustrate
+various features of WallGoMatrix:
 - `2hdm.m` gives the matrix elements for the Two Higgs Doublet Model
 - `2scalars.m` gives the matrix elements for the pure scalar sector of the Two Higgs Doublet Model
 - `SMFull.m` gives the matrix elements for the StandardModel
 - `SMSimplified.m` gives the matrix elements for the StandardModel (only quarks + gauge bosons)
-- `idm.m` gives the matrix elements for InertDoubletModel
-- `qcd.m` gives the matrix elements for ManySinglets and SingletStandardModel_Z2
-- `xsm.m` gives the matrix elements for SingletStandardModel_Z2 beyond the QCD sector
 - `weak.m` gives the matrix elements for QCD and W-bosons
-- `yukawa.m` gives the matrix elements for the Yukawa Model
 
-The WallGo repository contains copies of these example files.
+The WallGo repository contains copies of these example files.i


### PR DESCRIPTION
This pull request updates WallGoMatrix to support the latest version of its GroupMath dependency, refines documentation for clarity and accuracy, and improves the build process. The most significant changes include updating the GroupMath version, enhancing the example documentation, and adjusting the build directory structure.

**Dependency and compatibility updates:**

* Updated the required GroupMath version from 1.1.2 to 1.1.3 in both the `README.md` and the code that handles package installation, ensuring compatibility with the latest features and bug fixes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96) [[2]](diffhunk://#diff-19a4acf311e51755bd9e217049c810e249303fccbcd9d896c5132c843a4309f8L446-R449)

**Documentation improvements:**

* Expanded and clarified the `examples/README.md` by formatting code blocks properly and providing a more detailed mapping between model files and the models they implement.

**Build process enhancements:**

* Changed the temporary build directory in `buildPaclet.m` to reside within a `build` subfolder, improving organization of build artifacts.

**Administrative updates:**

* Updated copyright years in `Kernel/modelCreation.m` to include 2025.